### PR TITLE
Cog inheritance and listener decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 *.jpg
 config.py
 database/data/sqlite3.db
+
+\.idea/

--- a/ALBot.py
+++ b/ALBot.py
@@ -5,7 +5,7 @@ from discord.ext import commands
 import cogs.CONSTANTS as CONSTANTS
 import config
 
-'''Cogs to load when the bot first starts'''
+"""Cogs to load when the bot first starts"""
 startup_cogs = [
     "cogs.messages",
     "cogs.errors",

--- a/ALBot.py
+++ b/ALBot.py
@@ -38,5 +38,5 @@ if __name__ == "__main__":
         except Exception as e:
             exc = '{}: {}'.format(type(e).__name__, e)
             print('Failed to load extension {}\n{}'.format(extension, exc))
-
+            
 bot.run(config.ALBOT_TOKEN)

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -7,12 +7,7 @@ import io
 
 import cogs.util
 
-<<<<<<< HEAD
-class Admin:
-=======
-
-class Admin(commands.Cog, name="Admin"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
+class Admin(commands.Cog, name='Admin'):
 
     def __init__(self, bot):
         self.bot = bot
@@ -20,7 +15,7 @@ class Admin(commands.Cog, name="Admin"):
     @commands.command(hidden=True)
     @commands.check(cogs.util.is_officer_check)
     async def load(self, ctx, extension_name : str):
-        '''Loads an extension.'''
+        """Loads an extension."""
         try:
             if extension_name.startswith("cogs."):
                 self.bot.load_extension(extension_name)
@@ -44,7 +39,7 @@ class Admin(commands.Cog, name="Admin"):
     @commands.command(hidden=True)
     @commands.check(cogs.util.is_officer_check)
     async def reload(self, ctx, extension_name : str):
-        '''Unloads and then loads an extension'''
+        """Unloads and then loads an extension"""
         try:
             if extension_name.startswith("cogs."):
                 self.bot.unload_extension(extension_name)
@@ -65,7 +60,7 @@ class Admin(commands.Cog, name="Admin"):
     @commands.command(hidden=True, name="eval")
     @commands.check(cogs.util.is_owner)
     async def admin_eval(self, ctx, *, cmd : str):
-        '''Evaluates Python code only if the executor is hjarrell'''
+        """Evaluates Python code only if the executor is hjarrell"""
         env = {
             'bot': self.bot,
             'discord': discord,
@@ -88,7 +83,7 @@ class Admin(commands.Cog, name="Admin"):
                 ret = await eval("__admin_eval()", env)
         except Exception as e:
             value = stdout.getvalue()
-            await ctx.send("```py\n{value}{e}\n```".format())
+            await ctx.send("```py\n{}{}\n```".format(value, e))
         else:
             value = stdout.getvalue()
             if ret is None:

--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -7,7 +7,12 @@ import io
 
 import cogs.util
 
+<<<<<<< HEAD
 class Admin:
+=======
+
+class Admin(commands.Cog, name="Admin"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
 
     def __init__(self, bot):
         self.bot = bot

--- a/cogs/compile.py
+++ b/cogs/compile.py
@@ -5,11 +5,8 @@ import json
 
 import cogs.util
 
-<<<<<<< HEAD
-class Compile:
-=======
-class Compile(commands.Cog, name="Compile"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
+class Compile(commands.Cog, name='Compile'):
+
     def __init__(self, bot):
         self.bot = bot
         self.complangs = []
@@ -17,7 +14,7 @@ class Compile(commands.Cog, name="Compile"):
 
     @commands.command(name="complangs")
     async def compile_langs(self, ctx):
-        '''Get the languages and ids for compiling code'''
+        """Get the languages and ids for compiling code"""
         if len(self.complangs) == 0:
             langs = requests.get("https://api.judge0.com/languages")
 
@@ -31,7 +28,7 @@ class Compile(commands.Cog, name="Compile"):
 
     @commands.command(name="compile")
     async def _compile(self, ctx, lang_id : int, *, program : str):
-        '''Compiles and runs code using the judge0 api'''
+        """Compiles and runs code using the judge0 api"""
         payload = {'source_code' : program, 'language_id' : lang_id}
         headers = {'Content-Type': "application/json"}
         r = requests.post("https://api.judge0.com/submissions/?base64_encoded=false&wait=true", data=json.dumps(payload), headers=headers)
@@ -47,7 +44,7 @@ class Compile(commands.Cog, name="Compile"):
     @commands.command(name="compdebug")
     @commands.check(cogs.util.is_officer_check)
     async def debug_compile(self, ctx):
-        '''Toggles whether to print the full compile output'''
+        """Toggles whether to print the full compile output"""
         self.is_debug = not self.is_debug
         await ctx.send("is_debugging = {}".format(self.is_debug))
 

--- a/cogs/compile.py
+++ b/cogs/compile.py
@@ -5,7 +5,11 @@ import json
 
 import cogs.util
 
+<<<<<<< HEAD
 class Compile:
+=======
+class Compile(commands.Cog, name="Compile"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     def __init__(self, bot):
         self.bot = bot
         self.complangs = []

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -9,7 +9,11 @@ import cogs.CONSTANTS as CONSTANTS
 from database.database import SQLCursor, SQLConnection
 from cogs.messages import track
 
+<<<<<<< HEAD
 class ALBotErrorHandlers:
+=======
+class ALBotErrorHandlers(commands.Cog, name = "Error Handler"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     """ Handles errors """
 
     def __init__(self, bot, db):
@@ -69,7 +73,12 @@ class ALBotErrorHandlers:
                 bt_string = ''.join(traceback.format_exception(type(error), error, error.__traceback__))
                 print('{bname} encountered an error:\n{0}'.format(bt_string, bname=CONSTANTS.BOT_NAME))
                 cur.execute('INSERT INTO error_messages (message_id, channel_id, command_name, error_name, error_text, full_backtrace, full_command_string) VALUES (?,?,?,?,?,?,?);',(msg.id, msg.channel.id, ctx.command.name, str(type(error)), str(error), bt_string, ctx.message.content))
+<<<<<<< HEAD
     
+=======
+
+    @commands.Cog.listener()
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     async def on_raw_reaction_add(self, payload):
         if payload.user_id == self.bot.user.id:
             return
@@ -84,7 +93,12 @@ class ALBotErrorHandlers:
             to_edit = await self.bot.get_channel(payload.channel_id).get_message(payload.message_id)
             new_embed = self._construct_error_embed(row[0],row[1],row[2],row[3],row[4])
             await to_edit.edit(content='{err} Command error {err}'.format(err=CONSTANTS.REACTION_ERROR),embed=new_embed)
+<<<<<<< HEAD
     
+=======
+
+    @commands.Cog.listener()
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     async def on_raw_reaction_remove(self, payload):
         if payload.user_id == self.bot.user.id:
             return

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -9,13 +9,8 @@ import cogs.CONSTANTS as CONSTANTS
 from database.database import SQLCursor, SQLConnection
 from cogs.messages import track
 
-<<<<<<< HEAD
-class ALBotErrorHandlers:
-=======
-class ALBotErrorHandlers(commands.Cog, name = "Error Handler"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
+class ALBotErrorHandlers(commands.Cog, name='Error Handler'):
     """ Handles errors """
-
     def __init__(self, bot, db):
         self.bot = bot
         self.db = db
@@ -73,12 +68,12 @@ class ALBotErrorHandlers(commands.Cog, name = "Error Handler"):
                 bt_string = ''.join(traceback.format_exception(type(error), error, error.__traceback__))
                 print('{bname} encountered an error:\n{0}'.format(bt_string, bname=CONSTANTS.BOT_NAME))
                 cur.execute('INSERT INTO error_messages (message_id, channel_id, command_name, error_name, error_text, full_backtrace, full_command_string) VALUES (?,?,?,?,?,?,?);',(msg.id, msg.channel.id, ctx.command.name, str(type(error)), str(error), bt_string, ctx.message.content))
-<<<<<<< HEAD
+
     
-=======
+
 
     @commands.Cog.listener()
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
+
     async def on_raw_reaction_add(self, payload):
         if payload.user_id == self.bot.user.id:
             return
@@ -93,12 +88,8 @@ class ALBotErrorHandlers(commands.Cog, name = "Error Handler"):
             to_edit = await self.bot.get_channel(payload.channel_id).get_message(payload.message_id)
             new_embed = self._construct_error_embed(row[0],row[1],row[2],row[3],row[4])
             await to_edit.edit(content='{err} Command error {err}'.format(err=CONSTANTS.REACTION_ERROR),embed=new_embed)
-<<<<<<< HEAD
-    
-=======
 
     @commands.Cog.listener()
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     async def on_raw_reaction_remove(self, payload):
         if payload.user_id == self.bot.user.id:
             return

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -44,6 +44,7 @@ class ALBotErrorHandlers(commands.Cog, name='Error Handler'):
 
         return embed
 
+    @commands.Cog.listener()
     async def on_command_error(self, ctx, error):
         if type(error) == discord.ext.commands.MissingPermissions:
             await ctx.message.add_reaction(CONSTANTS.REACTION_DENY)

--- a/cogs/errors.py
+++ b/cogs/errors.py
@@ -69,11 +69,7 @@ class ALBotErrorHandlers(commands.Cog, name='Error Handler'):
                 print('{bname} encountered an error:\n{0}'.format(bt_string, bname=CONSTANTS.BOT_NAME))
                 cur.execute('INSERT INTO error_messages (message_id, channel_id, command_name, error_name, error_text, full_backtrace, full_command_string) VALUES (?,?,?,?,?,?,?);',(msg.id, msg.channel.id, ctx.command.name, str(type(error)), str(error), bt_string, ctx.message.content))
 
-    
-
-
     @commands.Cog.listener()
-
     async def on_raw_reaction_add(self, payload):
         if payload.user_id == self.bot.user.id:
             return

--- a/cogs/helloworld.py
+++ b/cogs/helloworld.py
@@ -2,19 +2,14 @@ import discord
 from discord.ext import commands
 import os
 
-<<<<<<< HEAD
-class HelloWorld:
-=======
-class HelloWorld(commands.Cog, name = "Hello World"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
-    '''Discord.py Cog for printing the hello world code for different languages'''
-
+class HelloWorld(commands.Cog, name='Hello World'):
+    """Discord.py Cog for printing the hello world code for different languages"""
     def __init__(self, bot):
         self.bot = bot
 
     @commands.command()
     async def hello(self, ctx, lang : str):
-        '''Prints the hello world source for any language defined in cogs/helloworld'''
+        """Prints the hello world source for any language defined in cogs/helloworld"""
         for fName in os.listdir("cogs/helloworld"):
             if fName == (lang.lower() + ".txt"):
                 with open("cogs/helloworld/{}".format(fName), 'r') as f:
@@ -22,7 +17,7 @@ class HelloWorld(commands.Cog, name = "Hello World"):
 
     @commands.command()
     async def hellolangs(self, ctx):
-        '''Prints all the languages that there are helloworld's for'''
+        """Prints all the languages that there are helloworld's for"""
         langs = ''
         for fName in os.listdir("cogs/helloworld"):
             langs += fName.replace('.txt','') + '\n'

--- a/cogs/helloworld.py
+++ b/cogs/helloworld.py
@@ -2,7 +2,11 @@ import discord
 from discord.ext import commands
 import os
 
+<<<<<<< HEAD
 class HelloWorld:
+=======
+class HelloWorld(commands.Cog, name = "Hello World"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     '''Discord.py Cog for printing the hello world code for different languages'''
 
     def __init__(self, bot):

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -1,0 +1,26 @@
+import discord
+import random
+from discord.ext import commands
+
+class Help:
+    '''Commands related to help needed'''
+    def __init__(self, bot):
+        self.bot = bot
+    
+    
+    @commands.command()
+    async def question(self, ctx, *, q : str = ""):
+        ''' Forward a question to the officer chat
+            Formats:
+            !question
+            !question [question to be answered]
+        '''
+        member_name = ctx.message.author.name
+        channel = self.bot.get_channel(436916990238785556)
+        await channel.send("@everyone\n @"+member_name+" has a question!")
+        if (q != ""):
+            await channel.send("\""+q+"\"")
+    
+
+def setup(bot):
+    bot.add_cog(Help(bot))

--- a/cogs/help.py
+++ b/cogs/help.py
@@ -2,19 +2,18 @@ import discord
 import random
 from discord.ext import commands
 
-class Help:
-    '''Commands related to help needed'''
+class Help(commands.Cog, name='Help'):
+    """Commands related to help needed"""
     def __init__(self, bot):
         self.bot = bot
     
-    
     @commands.command()
     async def question(self, ctx, *, q : str = ""):
-        ''' Forward a question to the officer chat
+        """ Forward a question to the officer chat
             Formats:
             !question
             !question [question to be answered]
-        '''
+        """
         member_name = ctx.message.author.name
         channel = self.bot.get_channel(436916990238785556)
         await channel.send("@everyone\n @"+member_name+" has a question!")

--- a/cogs/memes.py
+++ b/cogs/memes.py
@@ -4,13 +4,8 @@ from discord.ext import commands
 
 import cogs.util
 
-<<<<<<< HEAD
-class Memes:
-=======
-class Memes(commands.Cog, name = "Memes"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
-    '''All meme related commands'''
-
+class Memes(commands.Cog, name='Memes'):
+    """All meme related commands"""
     def __init__(self, bot):
         self.bot = bot
         self.playing_strings = []
@@ -19,24 +14,24 @@ class Memes(commands.Cog, name = "Memes"):
 
     @commands.command()
     async def orange(self, ctx):
-        '''Responds to the classic football chant "Orange" "Blue"'''
+        """Responds to the classic football chant "Orange" "Blue"""
         await ctx.send("BLUE!")
 
     @commands.command()
     async def blue(self, ctx):
-        '''Responds to the classic football chant "Orange" "Blue"'''
+        """Responds to the classic football chant "Orange" "Blue"""
         await ctx.send("ORANGE!")
 
     @commands.command()
     async def about(self, ctx):
-        '''Prints information about the bots.'''
+        """Prints information about the bots."""
         await ctx.send("We are your benevolent dictators. Fear us.")
         await ctx.send(file=discord.File('alligator.jpg'))
 
     @commands.command()
     @commands.check(cogs.util.is_officer_check)
     async def randplaying(self, ctx):
-        '''Randomly changes the playing text'''
+        """Randomly changes the playing text"""
         new_playing = random.choice(self.playing_strings)
         await self.bot.change_presence(activity=discord.Game(name=new_playing))
         await ctx.send('I am now {}'.format(new_playing))
@@ -44,20 +39,18 @@ class Memes(commands.Cog, name = "Memes"):
     @commands.command()
     @commands.check(cogs.util.is_officer_check)
     async def setplaying(self, ctx, *, playing: str):
-        '''Lets an officer set the playing text'''
+        """Lets an officer set the playing text"""
         await self.bot.change_presence(activity=discord.Game(name=playing))
 
     @commands.command()
     async def say(self, ctx, *, phrase : str):
-        '''Has the bot say something'''
+        """Has the bot say something"""
         await ctx.send(phrase)
 
-<<<<<<< HEAD
-=======
     async def on_guild_channel_create(self, channel):
-        '''Messages "First" when a channel is created'''
+        """Messages "First" when a channel is created"""
         await channel.send('First')
 
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
+
 def setup(bot):
     bot.add_cog(Memes(bot))

--- a/cogs/memes.py
+++ b/cogs/memes.py
@@ -4,7 +4,11 @@ from discord.ext import commands
 
 import cogs.util
 
+<<<<<<< HEAD
 class Memes:
+=======
+class Memes(commands.Cog, name = "Memes"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     '''All meme related commands'''
 
     def __init__(self, bot):
@@ -48,5 +52,12 @@ class Memes:
         '''Has the bot say something'''
         await ctx.send(phrase)
 
+<<<<<<< HEAD
+=======
+    async def on_guild_channel_create(self, channel):
+        '''Messages "First" when a channel is created'''
+        await channel.send('First')
+
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
 def setup(bot):
     bot.add_cog(Memes(bot))

--- a/cogs/messages.py
+++ b/cogs/messages.py
@@ -11,6 +11,31 @@ class ALBotMessageDeletionHandlers(commands.Cog, name='Message Deletion Handlers
         self.db = db
 
     @commands.Cog.listener()
+    async def on_message(self, msg):
+        """Checks message for factorial format using regex."""
+        if msg.author != self.bot.user:
+            import re
+            filtered_msg = re.findall('{(?:[0-9]|[1-8](?:[0-9]{1,2})?)!}',
+                                      msg.content)
+            if filtered_msg is not None:
+                group_len = len(filtered_msg)
+                print('Groups: ' + str(group_len))
+                factorial = 'Factorial: `{}! = {}`' if group_len == 1 else 'The following factorials were calculated as:```'
+                import math
+                if group_len > 1:
+                    for i in range(0, group_len):
+                        num = int((filtered_msg[i].split('!')[0])[1:])
+                        product = math.factorial(num)
+                        factorial += '\n\n{}! = {}'.format(num, product)
+                    await msg.channel.send(factorial + '```')
+                elif group_len == 1:
+                    num = int((filtered_msg[0].split('!')[0])[1:])
+                    await msg.channel.send(
+                        factorial.format(num, math.factorial(num)))
+
+        await self.bot.process_commands(msg)
+
+    @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
         """ Checks reactions and deletes tracked messages when necessary. """
         if payload.user_id == self.bot.user.id:

--- a/cogs/messages.py
+++ b/cogs/messages.py
@@ -4,12 +4,13 @@ from discord.ext import commands
 import cogs.CONSTANTS as CONSTANTS
 from database.database import SQLCursor, SQLConnection
 
-class ALBotMessageDeletionHandlers:
+class ALBotMessageDeletionHandlers(commands.Cog, name='Message Deletion Handlers'):
     """ Functions for handling tracked messages """
     def __init__(self, bot, db):
         self.bot = bot
         self.db = db
 
+    @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
         """ Checks reactions and deletes tracked messages when necessary. """
         if payload.user_id == self.bot.user.id:

--- a/cogs/messages.py
+++ b/cogs/messages.py
@@ -44,36 +44,5 @@ async def track(message, author=None):
     with SQLCursor(sql_db) as cur:
                 cur.execute("INSERT INTO tracked_messages (messid, sender_uid, track_time) VALUES (?, ?, ?);", (message.id, aid, message.created_at))
 
-class ALBotFactorialHandler(commands.Cog, name='Factorial Handler'):
-
-    def __init__(self, bot):
-        self.bot = bot
-
-    @commands.Cog.listener()
-    async def on_message(self, msg):
-        """Checks message for factorial format using regex."""
-        if msg.author != self.bot.user:
-            import re
-            filtered_msg = re.findall('{(?:[0-9]|[1-8](?:[0-9]{1,2})?)!}', msg.content)
-            if filtered_msg is not None:
-                group_len = len(filtered_msg)
-                factorial = 'Factorial: `{}! = {}`' if group_len == 1 else 'The following factorials were calculated as:```'
-                import math
-                if group_len > 1:
-                    for i in range(0, group_len):
-                        num = int((filtered_msg[i].split('!')[0])[1:])
-                        product = math.factorial(num)
-                        factorial += '\n\n{}! = {}'.format(num, product)
-                    await msg.channel.send(factorial + '```')
-                elif group_len == 1:
-                    try:
-                        num = int((filtered_msg[0].split('!')[0])[1:])
-                        await msg.channel.send(factorial.format(num, math.factorial(num)))
-                    except discord.HTTPException as e:
-                        await msg.channel.send('Cannot post answer due to excessive character count! Maximum factorial allowed is `801!`.')
-
-        await self.bot.process_commands(msg)
-
 def setup(bot):
     bot.add_cog(ALBotMessageDeletionHandlers(bot, SQLConnection()))
-    bot.add_cog(ALBotFactorialHandler(bot))

--- a/cogs/messages.py
+++ b/cogs/messages.py
@@ -11,31 +11,6 @@ class ALBotMessageDeletionHandlers(commands.Cog, name='Message Deletion Handlers
         self.db = db
 
     @commands.Cog.listener()
-    async def on_message(self, msg):
-        """Checks message for factorial format using regex."""
-        if msg.author != self.bot.user:
-            import re
-            filtered_msg = re.findall('{(?:[0-9]|[1-8](?:[0-9]{1,2})?)!}',
-                                      msg.content)
-            if filtered_msg is not None:
-                group_len = len(filtered_msg)
-                print('Groups: ' + str(group_len))
-                factorial = 'Factorial: `{}! = {}`' if group_len == 1 else 'The following factorials were calculated as:```'
-                import math
-                if group_len > 1:
-                    for i in range(0, group_len):
-                        num = int((filtered_msg[i].split('!')[0])[1:])
-                        product = math.factorial(num)
-                        factorial += '\n\n{}! = {}'.format(num, product)
-                    await msg.channel.send(factorial + '```')
-                elif group_len == 1:
-                    num = int((filtered_msg[0].split('!')[0])[1:])
-                    await msg.channel.send(
-                        factorial.format(num, math.factorial(num)))
-
-        await self.bot.process_commands(msg)
-
-    @commands.Cog.listener()
     async def on_raw_reaction_add(self, payload):
         """ Checks reactions and deletes tracked messages when necessary. """
         if payload.user_id == self.bot.user.id:
@@ -68,7 +43,6 @@ async def track(message, author=None):
         aid = author.id
     with SQLCursor(sql_db) as cur:
                 cur.execute("INSERT INTO tracked_messages (messid, sender_uid, track_time) VALUES (?, ?, ?);", (message.id, aid, message.created_at))
-
 
 def setup(bot):
     bot.add_cog(ALBotMessageDeletionHandlers(bot, SQLConnection()))

--- a/cogs/messages.py
+++ b/cogs/messages.py
@@ -44,5 +44,36 @@ async def track(message, author=None):
     with SQLCursor(sql_db) as cur:
                 cur.execute("INSERT INTO tracked_messages (messid, sender_uid, track_time) VALUES (?, ?, ?);", (message.id, aid, message.created_at))
 
+class ALBotFactorialHandler(commands.Cog, name='Factorial Handler'):
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_message(self, msg):
+        """Checks message for factorial format using regex."""
+        if msg.author != self.bot.user:
+            import re
+            filtered_msg = re.findall('{(?:[0-9]|[1-8](?:[0-9]{1,2})?)!}', msg.content)
+            if filtered_msg is not None:
+                group_len = len(filtered_msg)
+                factorial = 'Factorial: `{}! = {}`' if group_len == 1 else 'The following factorials were calculated as:```'
+                import math
+                if group_len > 1:
+                    for i in range(0, group_len):
+                        num = int((filtered_msg[i].split('!')[0])[1:])
+                        product = math.factorial(num)
+                        factorial += '\n\n{}! = {}'.format(num, product)
+                    await msg.channel.send(factorial + '```')
+                elif group_len == 1:
+                    try:
+                        num = int((filtered_msg[0].split('!')[0])[1:])
+                        await msg.channel.send(factorial.format(num, math.factorial(num)))
+                    except discord.HTTPException as e:
+                        await msg.channel.send('Cannot post answer due to excessive character count! Maximum factorial allowed is `801!`.')
+
+        await self.bot.process_commands(msg)
+
 def setup(bot):
     bot.add_cog(ALBotMessageDeletionHandlers(bot, SQLConnection()))
+    bot.add_cog(ALBotFactorialHandler(bot))

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -9,7 +9,11 @@ from discord.ext import commands
 import asyncio
 import youtube_dl
 
+<<<<<<< HEAD
 class VoiceEntry:
+=======
+class VoiceEntry(commands.Cog, name="Voice Entry"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     '''A class that represents a song that can be played'''
     def __init__(self, message, player, title, uploader, duration):
         self.requester = message.author

--- a/cogs/music.py
+++ b/cogs/music.py
@@ -9,12 +9,9 @@ from discord.ext import commands
 import asyncio
 import youtube_dl
 
-<<<<<<< HEAD
 class VoiceEntry:
-=======
-class VoiceEntry(commands.Cog, name="Voice Entry"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
-    '''A class that represents a song that can be played'''
+
+    """A class that represents a song that can be played"""
     def __init__(self, message, player, title, uploader, duration):
         self.requester = message.author
         self.channel = message.channel
@@ -30,7 +27,7 @@ class VoiceEntry(commands.Cog, name="Voice Entry"):
         return fmt.format(self.title, self.uploader, self.requester)
 
 class VoiceState:
-    '''Holds the queued song and players for a guild server'''
+    """Holds the queued song and players for a guild server"""
     def __init__(self, bot):
         self.current = None
         self.voice = None
@@ -69,7 +66,7 @@ class VoiceState:
             self.voice.play(self.current.player)
             await self.play_next_song.wait()
 
-class Music:
+class Music(commands.Cog, name='Music'):
     """Voice related commands.
     Works in multiple servers at once.
     """

--- a/cogs/projects.py
+++ b/cogs/projects.py
@@ -2,9 +2,8 @@ import discord
 from discord.utils import get
 from discord.ext import commands
 
-class Projects:
-    '''Commands dealing with the different projects we are working on'''
-
+class Projects(commands.Cog, name='Projects'):
+    """Commands dealing with the different projects we are working on"""
     def __init__(self, bot):
         self.bot = bot
 

--- a/cogs/projects.py
+++ b/cogs/projects.py
@@ -2,7 +2,11 @@ import discord
 from discord.utils import get
 from discord.ext import commands
 
+<<<<<<< HEAD
 class Projects:
+=======
+class Projects(commands.Cog, name="Projects"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     '''Commands dealing with the different projects we are working on'''
 
     def __init__(self, bot):

--- a/cogs/projects.py
+++ b/cogs/projects.py
@@ -2,11 +2,7 @@ import discord
 from discord.utils import get
 from discord.ext import commands
 
-<<<<<<< HEAD
 class Projects:
-=======
-class Projects(commands.Cog, name="Projects"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     '''Commands dealing with the different projects we are working on'''
 
     def __init__(self, bot):

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -4,8 +4,8 @@ import datetime
 import asyncio
 from discord.ext import commands
 
-class Reminder:
-    '''To remind officers and members about things'''
+class Reminder(commands.Cog, name='Reminder'):
+    """To remind officers and members about things"""
     def __init__(self, bot):
         self.bot = bot
         self.book_room_bg_task = self.bot.loop.create_task(self.book_room_reminder())

--- a/cogs/reminder.py
+++ b/cogs/reminder.py
@@ -1,0 +1,32 @@
+import discord
+import random
+import datetime
+import asyncio
+from discord.ext import commands
+
+class Reminder:
+    '''To remind officers and members about things'''
+    def __init__(self, bot):
+        self.bot = bot
+        self.book_room_bg_task = self.bot.loop.create_task(self.book_room_reminder())
+    
+    async def book_room_reminder(self):
+        await self.bot.wait_until_ready()
+        channel = self.bot.get_channel(436916990238785556)
+        while True:
+            current_day_of_the_week = (str)(datetime.date.today().strftime("%A"))
+            #print (current_day_of_the_week)
+            if current_day_of_the_week == "Wednesday" or current_day_of_the_week == "Thursday":
+                await channel.send("@everyone Reminder to book rooms!")
+                # ideally, the bot would send the reminder on Wednesdat 12am, 
+                # but to account for when the bot starts running,
+                # the time below is 2 minutes less than 1 week,
+                # this allows the time to be slowly adjusted every week until it reaches 12am
+                await asyncio.sleep(604680) # a little less than a week
+            else:
+                # this line will run twice every week once 
+                # the time is stabilized as mentioned above
+                await asyncio.sleep(60) # check every 1 minute
+
+def setup(bot):
+    bot.add_cog(Reminder(bot))

--- a/cogs/util.py
+++ b/cogs/util.py
@@ -1,9 +1,9 @@
 import discord
 
 def is_officer_check(ctx):
-    '''Check to see if the author is an officer'''
+    """Check to see if the author is an officer"""
     return discord.utils.get(ctx.message.author.roles, name='officer') is not None
 
 def is_owner(ctx):
-    '''Check to see if the author is an hjarrell'''
+    """Check to see if the author is an hjarrell"""
     return ctx.message.author.id == 402565484072927235

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -3,7 +3,11 @@ from discord.utils import get
 from discord.ext import commands
 import config
 
+<<<<<<< HEAD
 class Welcome:
+=======
+class Welcome(commands.Cog, name="Welcome"):
+>>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
     '''To automatically welcome new members to the server'''
 
     def __init__(self, bot):

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -3,18 +3,13 @@ from discord.utils import get
 from discord.ext import commands
 import config
 
-<<<<<<< HEAD
-class Welcome:
-=======
 class Welcome(commands.Cog, name="Welcome"):
->>>>>>> parent of 1e08d60... Fixed cog inheritance and added factorial support.
-    '''To automatically welcome new members to the server'''
-
+    """To automatically welcome new members to the server"""
     def __init__(self, bot):
         self.bot = bot
 
     async def on_member_join(self, member):
-        fmt = '''Welcome {0.mention}! \nFeel free to use \"!question\" to let us know if you have any questions \nAnd you can also use \"!help\", all in the #bot-spam channel to find out about what you can do with our Discord bot ALBot :D '''
+        fmt = """Welcome {0.mention}! \nFeel free to use \"!question\" to let us know if you have any questions \nAnd you can also use \"!help\", all in the #bot-spam channel to find out about what you can do with our Discord bot ALBot :D """
         dm_channel = member.dm_channel
         if dm_channel == None:
             await member.create_dm()

--- a/database/INFO.md
+++ b/database/INFO.md
@@ -12,7 +12,7 @@ from sql.sql import SQLConnection, SQLCursor, SQLRollback
 
 connection = SQLConnection() # Checks the database integrity and returns a new connection object
 with SQLCursor(connection) as cursor: # The backend uses a context manager to wrap the cursor object
-	''' Get data from some_table '''
+	""" Get data from some_table """
 	cursor.execute('SELECT * FROM some_table;')
 	result = cursor.fetchall()
 
@@ -24,7 +24,7 @@ with SQLCursor(connection) as cursor: # The backend uses a context manager to wr
 some_message_id = 484572171608522771
 some_message_text = 'The Spanish Inquisition'
 with SQLCursor(connection) as cursor:
-	''' Insert values into some_table, sanitizing them to prevent naughty business. '''
+	""" Insert values into some_table, sanitizing them to prevent naughty business. """
 	cursor.execute('INSERT INTO some_table (message_id, message_text) VALUES (?,?);', (some_message_id, some_message_text))
 
 print('done') # Changes are automatically committed at the end of the 'with' statement.
@@ -37,7 +37,7 @@ some_message_text = 'My most embarassing secrets that I would never want in an S
 message_is_regretted = True
 
 with SQLCursor(connection) as cursor:
-	''' Insert a value, then roll it back '''
+	""" Insert a value, then roll it back """
 	cursor.execute('INSERT INTO some_table (message_id, message_text) VALUES (?, ?);', (some_message_id, some_message_text))
 
 	if message_is_regretted:


### PR DESCRIPTION
Updates for the latest version of discord.py under version: `discord.py-1.0.0a1706+g45af9fa
`
This commit adds the new `Cog `inheritance feature and sets a custom, key-worded name for each `Cog`. Re-name as you like in future commits--they're just temporary so the feature is known.

Each currently defined cog now inherits `commands.Cog`.
Each listener within a defined cog is now attributed with the `commands.Cog.listener()` decorator.